### PR TITLE
#31 [INFRA] Fix Docker entrypoint, CI workflow, and repo ignores

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.venv
+.codex
+
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+
+docs/_build/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,7 @@ name: CI
 
 on:
   push:
-    paths:
-      - '*.py'
-      - 'tests/**'
-      - 'Dockerfile'
-      - 'pyproject.toml'
-      - '.github/workflows/ci.yml'
   pull_request:
-    paths:
-      - '*.py'
-      - 'tests/**'
-      - 'Dockerfile'
-      - 'pyproject.toml'
-      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read
@@ -31,4 +19,4 @@ jobs:
         run: docker build -t kata-ci .
 
       - name: Run tests in Docker
-        run: docker run --rm --entrypoint python kata-ci -m pytest -q
+        run: docker run --rm kata-ci pytest -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ RUN pip install --no-cache-dir pytest
 
 COPY . .
 
-ENTRYPOINT ["python", "main.py"]
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD []

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$#" -eq 0 ]; then
+  exec python main.py
+fi
+
+case "$1" in
+  -*)
+    exec python main.py "$@"
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac


### PR DESCRIPTION
## Related Issue
Closes #31

## Changes
- Added `entrypoint.sh`: default runs `python main.py`, passthrough for `pytest` and other commands, `--step` forwarded correctly
- Updated `Dockerfile`: `chmod +x entrypoint.sh` + `ENTRYPOINT ["/app/entrypoint.sh"]`
- Fixed `ci.yml`: removed path filters so CI always runs; test step now uses `docker run --rm kata-ci pytest -q`
- Added `.dockerignore`: excludes `.git`, `.venv`, `__pycache__`, `docs/_build`, cache dirs

## Testing
- [ ] Tested locally
- [ ] Tests pass
- [ ] Pre-commit hooks pass