### PR TITLE
#33 [DOCS] Align Sphinx pipeline, user story inventory, and README

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -40,9 +40,8 @@ jobs:
       - name: Install dependencies
         run: pip install -r docs/requirements.txt
 
-      # TODO: If your README.md is at repo root, uncomment to copy it into docs/
-      # - name: Copy README into docs
-      #   run: cp README.md docs/README.md
+      - name: Copy root README into docs
+        run: cp README.md docs/README.md
 
       - name: Build Sphinx site
         run: sphinx-build -b html docs docs/_build/html

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 docs/_build/
 __pycache__/
+*.pyc
 .venv/
+.codex
+.codex/
+.pytest_cache/
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/nbskvc/sdp-powered-by-ai-agents-nikola-boskovic/actions/workflows/ci.yml/badge.svg)](https://github.com/nbskvc/sdp-powered-by-ai-agents-nikola-boskovic/actions/workflows/ci.yml)
 [![Docs](https://github.com/nbskvc/sdp-powered-by-ai-agents-nikola-boskovic/actions/workflows/docs-deploy.yml/badge.svg)](https://nbskvc.github.io/sdp-powered-by-ai-agents-nikola-boskovic/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/nbskvc/sdp-powered-by-ai-agents-nikola-boskovic/blob/main/LICENSE)
 
 A clean Python implementation of Conway's Game of Life, built as part of the *Software Development Processes Powered by AI Agents* course. The project demonstrates TDD/BDD practices, arc42 architecture documentation, and a fully automated CI/CD pipeline.
 
@@ -20,7 +20,7 @@ Conway's Game of Life is a zero-player cellular automaton. Given an initial grid
 | Layer | Choice |
 |---|---|
 | Language | Python 3.12 |
-| Data model | `Grid = frozenset[tuple[int, int]]` — pure, immutable |
+| Data model | `Grid = set[tuple[int, int]]` — sparse set of live cells |
 | Testing | pytest + pre-commit hooks |
 | Linting | ruff, black, isort |
 | Docs | Sphinx → GitHub Pages |
@@ -39,14 +39,14 @@ The core is split into three modules:
 **With Docker:**
 
 ```bash
-docker build -t game-of-life .
-docker run --rm game-of-life
+docker build -t kata-ci .
+docker run --rm kata-ci
 ```
 
-The container runs the full test suite by default. To run the simulation interactively instead:
+To run interactively (you’ll be prompted for grid size):
 
 ```bash
-docker run --rm game-of-life python main.py
+docker run --rm -it kata-ci
 ```
 
 **Without Docker:**
@@ -59,19 +59,13 @@ python main.py
 
 ## Run (Docker)
 
-**Build:**
-
-```bash
-docker build -t kata-ci .
-```
-
-**Default run (non-interactive — runs tests):**
+**Default run (non-interactive):**
 
 ```bash
 docker run --rm kata-ci
 ```
 
-**Step mode (interactive):**
+**Step mode (interactive, one generation per Enter):**
 
 ```bash
 docker run --rm -it kata-ci --step
@@ -79,24 +73,24 @@ docker run --rm -it kata-ci --step
 
 In step mode the program first prompts for a grid size (`NxN`), then advances one generation each time you press Enter.
 
-> **Note:** `--step` without `-it` exits immediately because Docker receives EOF on a non-interactive stdin. To pipe a fixed number of steps instead:
+> **Note:** `--step` without `-i` exits immediately because Docker receives EOF on a non-interactive stdin. To pipe a fixed number of steps instead:
 >
 > ```bash
 > printf "\n\n\n" | docker run --rm -i kata-ci --step
 > ```
 >
-> Each `\n` advances one generation (the first `\n` confirms the default grid size prompt).
+> Each `\n` advances one generation.
 
 ## Run Tests
 
 ```bash
-pytest
+.venv/bin/pytest -q
 ```
 
-Or via Docker (default container command):
+Or via Docker:
 
 ```bash
-docker run --rm game-of-life
+docker run --rm kata-ci pytest -q
 ```
 
 ## Documentation
@@ -126,4 +120,4 @@ Full Sphinx documentation (architecture, user stories, API) is published at:
 
 **Nikola Bošković** — [@nbskvc](https://github.com/nbskvc)
 
-*SDP Course — Module 5: TDD/BDD with AI Agents*
+*SDP Course — Module 6: Final Project*

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,92 +1,22 @@
-# Sphinx Documentation Starter
+# Conway's Game of Life
 
-Starter files for building a Sphinx documentation site for your kata project.
+A clean Python implementation of Conway's Game of Life, built as part of the *Software Development Processes Powered by AI Agents* course. The project demonstrates TDD/BDD practices, arc42 architecture documentation, and CI/CD pipelines.
 
-## Files
-
-| File | Purpose |
-|------|---------|
-| `conf.py` | Sphinx configuration — update project name, author, GitHub URL |
-| `index.rst` | Main index — add your architecture chapters and user story files |
-| `requirements.txt` | Python dependencies for Sphinx |
-| `Makefile` | Build commands (`make html`, `make clean`) |
-| `docs-deploy.yml` | GitHub Actions workflow — copy to `.github/workflows/` |
-
-## Setup
-
-### 1. Copy to your docs folder
+## Run (Docker)
 
 ```bash
-cp -r modules/module-6-project/starter/* docs/
+docker build -t kata-ci .
+docker run --rm kata-ci
 ```
 
-### 2. Edit `conf.py`
-
-Replace the TODO placeholders:
-
-```python
-project = "Mars Rover"              # Your kata name
-copyright = "2026, Your Name"       # Your name
-author = "Your Name"                # Your name
-
-html_theme_options = {
-    "project_name": "Mars Rover",   # Your kata name
-    "github_url": "https://github.com/YOUR_USERNAME/YOUR_REPO",
-}
-```
-
-### 3. Edit `index.rst`
-
-Update the toctree entries to match your actual file paths:
-
-```rst
-.. toctree::
-   :caption: Architecture:
-
-   architecture/01-introduction-and-goals
-   architecture/02-constraints
-   ...
-
-.. toctree::
-   :caption: User Stories:
-
-   user-stories/README
-   user-stories/rover-control
-   user-stories/grid-map
-```
-
-### 4. Install dependencies and build
+Step mode (one generation per Enter press):
 
 ```bash
-pip install -r docs/requirements.txt
-cd docs && make html
+docker run --rm -it kata-ci --step
 ```
 
-### 5. Preview locally
+Run tests in Docker:
 
 ```bash
-open docs/_build/html/index.html
-# or
-python -m http.server -d docs/_build/html 8000
+docker run --rm kata-ci pytest -q
 ```
-
-## GitHub Pages Deployment
-
-1. Copy the workflow file:
-
-```bash
-mkdir -p .github/workflows
-cp modules/module-6-project/starter/docs-deploy.yml .github/workflows/docs-deploy.yml
-```
-
-2. Enable GitHub Pages via CLI:
-
-```bash
-gh api repos/{owner}/{repo}/pages -X PUT -f build_type=workflow
-```
-
-Or manually: **Settings → Pages → Source → GitHub Actions**
-
-3. Push to `main` — the workflow triggers on changes to `README.md` or `docs/**`
-
-4. Your site will be live at `https://<username>.github.io/<repo-name>/`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Game of Life Documentation
 ==========================
 
-.. TODO: Replace "My Kata" with your kata name and add a short description.
+Console-based Conway's Game of Life kata with step mode and Sphinx documentation.
 
 .. toctree::
    :maxdepth: 2
@@ -34,6 +34,7 @@ Game of Life Documentation
    user-stories/GRID-STORY-001
    user-stories/SIM-STORY-001
    user-stories/RUNNER-STORY-001
+   user-stories/RUNNER-STORY-002
    user-stories/RENDER-STORY-001
 
 Indices and tables

--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -1,6 +1,6 @@
 # User Story Inventory
 
-## Pareto Progress: 4/4
+## Pareto Progress: 5/5
 ## Estimated value coverage: 100%
 
 ---
@@ -11,5 +11,6 @@
 |---|---|---|---|---|
 | 1 | [GRID-STORY-001](./GRID-STORY-001.md) | Represent live cells as a sparse set | ⭐ CORE | ✅ Approved |
 | 2 | [SIM-STORY-001](./SIM-STORY-001.md) | Compute next generation via Conway's rules | ⭐ CORE | ✅ Approved |
-| 3 | [RUNNER-STORY-001](./RUNNER-STORY-001.md) | Run the simulation loop for N generations | ⭐ CORE | 🔄 Updated |
-| 4 | [RENDER-STORY-001](./RENDER-STORY-001.md) | Render each generation to the console | ⭐ CORE | ✅ Approved |
+| 3 | [RUNNER-STORY-001](./RUNNER-STORY-001.md) | Run the simulation loop for N generations | ⭐ CORE | ✅ Approved |
+| 4 | [RUNNER-STORY-002](./RUNNER-STORY-002.md) | Advance the simulation one generation at a time with `--step` | ⭐ CORE | ✅ Approved |
+| 5 | [RENDER-STORY-001](./RENDER-STORY-001.md) | Render each generation to the console | ⭐ CORE | ✅ Approved |

--- a/docs/user-stories/RENDER-STORY-001.md
+++ b/docs/user-stories/RENDER-STORY-001.md
@@ -21,20 +21,20 @@ THEN
 
 ---
 
-## Scenario RENDER-STORY-001-S2: Dead cells within the bounding box are represented
+## Scenario RENDER-STORY-001-S2: Dead cells within the viewport are represented
 
 GIVEN
-* a grid where some cells within the bounding box are dead
+* a grid where some cells within the viewport are dead
 
 WHEN
 * `render(grid)` is called
 
 THEN
-* stdout contains a distinct character for dead cells at those positions
+* stdout contains a distinct character for dead cells at those positions (`.`)
 
 ---
 
-## Scenario RENDER-STORY-001-S3: Output is bounded by the live cell extents
+## Scenario RENDER-STORY-001-S3: Output is a fixed-size viewport
 
 GIVEN
 * a grid with live cells spanning rows 1–3 and columns 1–3
@@ -43,11 +43,11 @@ WHEN
 * `render(grid)` is called
 
 THEN
-* the printed output covers exactly that row/column range — no extra blank rows or columns beyond the bounding box
+* the printed output is a fixed-size viewport (default 8×8)
 
 ---
 
-## Scenario RENDER-STORY-001-S4: Empty grid produces no cell output
+## Scenario RENDER-STORY-001-S4: Empty grid renders as all dead cells
 
 GIVEN
 * an empty grid
@@ -56,41 +56,41 @@ WHEN
 * `render(grid)` is called
 
 THEN
-* no cell characters are written to stdout (output may be blank or a single newline)
+* stdout contains only the dead-cell character (`.`) and no live-cell character (`O`)
 
 ---
 
 # Backend Stories
 
-## RENDER-BE-001.1: Implement `render()` to print a bounding-box view to stdout
+## RENDER-BE-001.1: Implement `render()` to print a fixed viewport to stdout
 
 AS A developer
-I WANT `render(grid: Grid) -> None` to compute the bounding box of live cells and print each row
-SO THAT the console output faithfully represents the current generation
+I WANT `render(grid: Grid, size: int = 8) -> None` to print a fixed `size×size` viewport
+SO THAT the console output is stable and easy to compare across generations
 
-Architecture reference: architecture/05-building-block-view.md — `renderer` module; architecture/decisions/adr-001-sparse-set-grid.md — bounding box computed dynamically
+Architecture reference: architecture/05-building-block-view.md — `renderer` module; architecture/decisions/adr-001-sparse-set-grid.md — sparse live-cell set
 
-### Scenario RENDER-BE-001.1-S1: Bounding box is derived from live cell coordinates
+### Scenario RENDER-BE-001.1-S1: Fixed viewport is 8×8 by default
 
 GIVEN
-* a grid with live cells at {(0,0), (2,3)}
+* a grid with any live cells
 
 WHEN
 * `render(grid)` is called
 
 THEN
-* the output spans rows 0–2 and columns 0–3
+* stdout contains exactly 8 lines of 8 characters
 
-### Scenario RENDER-BE-001.1-S2: Each row is printed as a single line
+### Scenario RENDER-BE-001.1-S2: Live cells map to correct positions in the viewport
 
 GIVEN
-* a grid with 3 rows in its bounding box
+* a grid with live cells at known coordinates
 
 WHEN
 * `render(grid)` is called
 
 THEN
-* stdout receives exactly 3 lines of cell characters
+* the corresponding characters in stdout are marked as live (`O`)
 
 ### Scenario RENDER-BE-001.1-S3: `render` writes only to stdout, not stderr
 

--- a/docs/user-stories/RUNNER-STORY-001.md
+++ b/docs/user-stories/RUNNER-STORY-001.md
@@ -230,20 +230,20 @@ GIVEN
 * Docker is installed and running on localhost
 
 WHEN
-* `docker build -t game-of-life .` is executed
+* `docker build -t kata-ci .` is executed
 
 THEN
 * the build completes with exit code 0
-* an image tagged `game-of-life` exists in the local Docker image store
+* an image tagged `kata-ci` exists in the local Docker image store
 
 ### Scenario RUNNER-INFRA-001.3-S2: Docker container runs and exits cleanly
 
 GIVEN
-* the `game-of-life` image has been built successfully
+* the `kata-ci` image has been built successfully
 
 WHEN
-* `docker run --rm game-of-life` is executed
+* `docker run --rm kata-ci` is executed
 
 THEN
-* the container starts, executes the default `CMD`, and exits with code 0
+* the container starts, executes the default entrypoint, and exits with code 0
 * no container artefact remains after the run (`--rm` flag)

--- a/docs/user-stories/RUNNER-STORY-002.md
+++ b/docs/user-stories/RUNNER-STORY-002.md
@@ -162,6 +162,18 @@ THEN
 * no read is attempted on stdin
 * `next_generation` and `render` are each called exactly 3 times
 
+### Scenario RUNNER-BE-002.2-S5: `run()` passes viewport size to `render()`
+
+GIVEN
+* `run(grid, generations=2, step=False, size=12)` is called
+* `render` is observable (spy/mock)
+
+WHEN
+* the function runs to completion
+
+THEN
+* `render` is called with `size=12` on each iteration
+
 ---
 
 # Infrastructure Stories


### PR DESCRIPTION
## Related Issue
Closes #33

## Changes
- Enabled README copy step in `docs-deploy.yml`
- Added `user-stories/RUNNER-STORY-002` to `docs/index.rst` toctree; removed TODO placeholder
- Updated user story inventory to 5/5 with RUNNER-STORY-002 row
- Updated RENDER-STORY-001: fixed viewport terminology (8×8), removed bounding-box language
- Fixed RUNNER-STORY-001: `game-of-life` → `kata-ci` Docker image references
- Replaced `docs/README.md` starter content with real project overview
- Fixed `README.md`: Grid type, Docker commands, module description, license badge URL
- Expanded `.gitignore` with `*.pyc`, `.pytest_cache/`, `.ruff_cache/`, `.codex/`

## Testing
- [ ] Tested locally
- [ ] Tests pass
- [ ] Pre-commit hooks pass