### PR TITLE
#35 [DOCS] Convert documentation link in README to a symbolic hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker run --rm kata-ci pytest -q
 
 Full Sphinx documentation (architecture, user stories, API) is published at:
 
-**https://nbskvc.github.io/sdp-powered-by-ai-agents-nikola-boskovic/**
+**[nbskvc.github.io/sdp-powered-by-ai-agents-nikola-boskovic](https://nbskvc.github.io/sdp-powered-by-ai-agents-nikola-boskovic/)**
 
 ## Project Structure
 


### PR DESCRIPTION
## Related Issue
Closes #35

## Changes
- Replaced plain text documentation URL with a Markdown hyperlink with descriptive anchor text

## Testing
- [x] Tested locally
- [x] Tests pass
- [x] Pre-commit hooks pass